### PR TITLE
NSString VFL category

### DIFF
--- a/Parus.xcodeproj/project.pbxproj
+++ b/Parus.xcodeproj/project.pbxproj
@@ -9,6 +9,13 @@
 /* Begin PBXBuildFile section */
 		2253EB09196615190059262F /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2253EB08196615190059262F /* XCTest.framework */; };
 		2253EB79196895FE0059262F /* PVView+PVConvenientShorthands.m in Sources */ = {isa = PBXBuildFile; fileRef = 2253EB78196895FE0059262F /* PVView+PVConvenientShorthands.m */; };
+		2253EB8719689AAB0059262F /* NSString+PVConvenientShorthands.h in Headers */ = {isa = PBXBuildFile; fileRef = 2253EB8519689AAB0059262F /* NSString+PVConvenientShorthands.h */; };
+		2253EB8819689AAB0059262F /* NSString+PVConvenientShorthands.m in Sources */ = {isa = PBXBuildFile; fileRef = 2253EB8619689AAB0059262F /* NSString+PVConvenientShorthands.m */; };
+		2253EB8919689AAB0059262F /* NSString+PVConvenientShorthands.m in Sources */ = {isa = PBXBuildFile; fileRef = 2253EB8619689AAB0059262F /* NSString+PVConvenientShorthands.m */; };
+		2253EB8A19689AAB0059262F /* NSString+PVConvenientShorthands.m in Sources */ = {isa = PBXBuildFile; fileRef = 2253EB8619689AAB0059262F /* NSString+PVConvenientShorthands.m */; };
+		2253EB9219689AB90059262F /* PVView+PVConvenientShorthands.m in Sources */ = {isa = PBXBuildFile; fileRef = 2253EB78196895FE0059262F /* PVView+PVConvenientShorthands.m */; };
+		2253EB9319689ABA0059262F /* PVView+PVConvenientShorthands.m in Sources */ = {isa = PBXBuildFile; fileRef = 2253EB78196895FE0059262F /* PVView+PVConvenientShorthands.m */; };
+		2253EB9419689AC90059262F /* PVView+PVConvenientShorthands.h in Headers */ = {isa = PBXBuildFile; fileRef = 2253EB77196895FE0059262F /* PVView+PVConvenientShorthands.h */; };
 		2261065D196613030004EDA5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2261065C196613030004EDA5 /* UIKit.framework */; };
 		226BAC891966075200C329F5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4838D55E176DDD19009415E4 /* Foundation.framework */; };
 		226BAC8B1966075A00C329F5 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 226BAC8A1966075A00C329F5 /* AppKit.framework */; };
@@ -192,6 +199,8 @@
 		2253EB08196615190059262F /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		2253EB77196895FE0059262F /* PVView+PVConvenientShorthands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PVView+PVConvenientShorthands.h"; sourceTree = "<group>"; };
 		2253EB78196895FE0059262F /* PVView+PVConvenientShorthands.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PVView+PVConvenientShorthands.m"; sourceTree = "<group>"; };
+		2253EB8519689AAB0059262F /* NSString+PVConvenientShorthands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+PVConvenientShorthands.h"; sourceTree = "<group>"; };
+		2253EB8619689AAB0059262F /* NSString+PVConvenientShorthands.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+PVConvenientShorthands.m"; sourceTree = "<group>"; };
 		2261065C196613030004EDA5 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		226BAC3B1965FC5B00C329F5 /* PVUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = PVUtilities.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		226BAC67196600B000C329F5 /* libParus-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libParus-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -380,6 +389,8 @@
 				8654BB40177439A700B0AB6D /* PVVFLImp.m */,
 				86CAAAFB17ABA2DE0026DA46 /* PVVFLContext.h */,
 				86CAAAFC17ABA2DE0026DA46 /* PVVFLContext.m */,
+				2253EB8519689AAB0059262F /* NSString+PVConvenientShorthands.h */,
+				2253EB8619689AAB0059262F /* NSString+PVConvenientShorthands.m */,
 			);
 			name = VFL;
 			sourceTree = "<group>";
@@ -417,6 +428,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2253EB9419689AC90059262F /* PVView+PVConvenientShorthands.h in Headers */,
+				2253EB8719689AAB0059262F /* NSString+PVConvenientShorthands.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -614,7 +627,9 @@
 				226BAC911966078A00C329F5 /* PVLayoutImp.m in Sources */,
 				226BAC931966078A00C329F5 /* PVConstraintContext.m in Sources */,
 				226BAC961966078A00C329F5 /* PVGroupImpl.m in Sources */,
+				2253EB9219689AB90059262F /* PVView+PVConvenientShorthands.m in Sources */,
 				226BAC981966078A00C329F5 /* PVGroupContext.m in Sources */,
+				2253EB8A19689AAB0059262F /* NSString+PVConvenientShorthands.m in Sources */,
 				226BAC9B1966078A00C329F5 /* PVVFLImp.m in Sources */,
 				226BAC9D1966078A00C329F5 /* PVVFLContext.m in Sources */,
 			);
@@ -625,9 +640,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				22E9C00D187E16E300EC368A /* PVVFLSpec.m in Sources */,
+				2253EB9319689ABA0059262F /* PVView+PVConvenientShorthands.m in Sources */,
 				22E9C00C187E16E300EC368A /* PVLayoutSpec.m in Sources */,
 				22E9C00B187E16E300EC368A /* PVGroupSpec.m in Sources */,
 				22E9C00A187E16E300EC368A /* ConstraintContextSpec.m in Sources */,
+				2253EB8919689AAB0059262F /* NSString+PVConvenientShorthands.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -639,6 +656,7 @@
 				8654BB41177439A700B0AB6D /* PVVFLImp.m in Sources */,
 				226D711817A065B700CC9AF1 /* PVLayoutImp.m in Sources */,
 				86CAAAFD17ABA2DE0026DA46 /* PVVFLContext.m in Sources */,
+				2253EB8819689AAB0059262F /* NSString+PVConvenientShorthands.m in Sources */,
 				2253EB79196895FE0059262F /* PVView+PVConvenientShorthands.m in Sources */,
 				48B8B0D117B6669D0078CD95 /* PVGroupImpl.m in Sources */,
 				48B46FED17C4FC8000A48463 /* PVGroupContext.m in Sources */,

--- a/Parus/src/NSString+PVConvenientShorthands.h
+++ b/Parus/src/NSString+PVConvenientShorthands.h
@@ -1,0 +1,16 @@
+//
+//  NSString+PVConvenientShorthands.h
+//  Parus
+//
+//  Created by nekoi on 7/5/14.
+//
+//
+
+#import "PVVFL.h"
+
+@interface NSString (PVConvenientShorthands)
+
+/// VFL start method
+- (_PVAlignmentOptionSelect*)pv_VFL;
+
+@end

--- a/Parus/src/NSString+PVConvenientShorthands.m
+++ b/Parus/src/NSString+PVConvenientShorthands.m
@@ -1,0 +1,18 @@
+//
+//  NSString+PVConvenientShorthands.m
+//  Parus
+//
+//  Created by nekoi on 7/5/14.
+//
+//
+
+#import "NSString+PVConvenientShorthands.h"
+
+@implementation NSString (PVConvenientShorthands)
+
+- (_PVAlignmentOptionSelect*)pv_VFL
+{
+    return PVVFL(self);
+}
+
+@end

--- a/Parus/src/PVGroupImpl.m
+++ b/Parus/src/PVGroupImpl.m
@@ -97,6 +97,15 @@ _PVGroup* PVGroup(NSArray* array)
                               toVFLContxt:l.context];
             [result addObjectsFromArray:[l.context buildConstraints]];
         }
+        else if ([object isKindOfClass:[NSString class]])
+        {
+            NSString* format = [object copy];
+            PVVFLLayout* l = [PVVFLLayout new];
+            l.context.format = format;
+            [self.class applyGroupContext:self.context
+                              toVFLContxt:l.context];
+            [result addObjectsFromArray:[l.context buildConstraints]];
+        }
     }
     
     return [result copy];

--- a/Parus/src/Parus.h
+++ b/Parus/src/Parus.h
@@ -8,3 +8,5 @@
 #import <Parus/PVLayout.h>
 #import <Parus/PVVFL.h>
 #import <Parus/PVGroup.h>
+#import <Parus/PVView+PVConvenientShorthands.h>
+#import <Parus/NSString+PVConvenientShorthands.h>

--- a/ParusXCTests/Specs/PVLayoutSpec.m
+++ b/ParusXCTests/Specs/PVLayoutSpec.m
@@ -1,6 +1,7 @@
 #import "PVLayout.h"
 
 #import "PVConstraintContext.h"
+#import "PVView+PVConvenientShorthands.h"
 
 SpecBegin(PVSpec)
 
@@ -74,6 +75,31 @@ describe(@"PVLayout", ^{
             expect(^{
                 PVWidthOf(view1).equalTo.widthOf(nil);
             }).to.raiseAny();
+        });
+    });
+    
+    describe(@"view category", ^{
+        __block PVView* view1 = nil;
+        __block PVView* view2 = nil;
+        
+        beforeEach(^{
+            view1 = [PVView new];
+            view2 = [PVView new];
+        });
+        
+        it(@"should return valid constraint", ^{
+            NSLayoutConstraint* constraint = view1.pv_left.equalTo.leftOf(view2).multipliedTo(2.f).minus(20.f).withPriority(PVLayoutPriorityFittingSizeLevel).asConstraint;
+            
+            expect(constraint).toNot.beNil();
+            expect(constraint).to.beInstanceOf([NSLayoutConstraint class]);
+            
+            expect(constraint.firstItem).to.equal(view1);
+            expect(constraint.firstAttribute).to.equal(NSLayoutAttributeLeft);
+            expect(constraint.relation).to.equal(NSLayoutRelationEqual);
+            expect(constraint.secondItem).to.equal(view2);
+            expect(constraint.secondAttribute).to.equal(NSLayoutAttributeLeft);
+            expect(constraint.multiplier).to.equal(2.f);
+            expect(constraint.constant).to.equal(-20.f);
         });
     });
     

--- a/ParusXCTests/Specs/PVVFLSpec.m
+++ b/ParusXCTests/Specs/PVVFLSpec.m
@@ -1,4 +1,5 @@
 #import "PVVFL.h"
+#import "NSString+PVConvenientShorthands.h"
 
 SpecBegin(PVVFL)
 
@@ -24,6 +25,8 @@ describe(@"PVVFL", ^{
         expect(PVVFL(@"V:|[view1]-20-[view2]|").alignAllLeft.fromLeadingToTrailing.withViews(NSDictionaryOfVariableBindings(view1, view2)).asArray).toNot.beNil();
         
         expect(PVVFL(@"[view1(>=width)]").withViews(NSDictionaryOfVariableBindings(view1)).metrics(@{@"width" : @200}).asArray).toNot.beNil();
+        
+        expect(@"[view1(>=width)]".pv_VFL.withViews(NSDictionaryOfVariableBindings(view1)).metrics(@{@"width" : @200}).asArray).toNot.beNil();
     });
     
     it(@"should produce simple constraint", ^{
@@ -42,8 +45,6 @@ describe(@"PVVFL", ^{
         expect(actual.relation).to.equal(expected.relation);
         expect(actual.secondItem).to.equal(expected.secondItem);
         expect(actual.secondAttribute).to.equal(expected.secondAttribute);
-
-        
     });
     
     it(@"should produce constraints with formatting option mask", ^{


### PR DESCRIPTION
@DAlOG @AndreyMoskvin #19 Check NSString category out and accept. 
There are commits available that resolve #27 and #20. Ignore them. :cat2: 
Also I've add here some convenient `PVGroup` addition:
From now on you can put inside `PVGroup` argument array simple `NSString` for VFL without need of some additions.
